### PR TITLE
Fix json code blocks

### DIFF
--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -25,17 +25,21 @@ your new project with ``dylan new application <name>``, and edit the file
 Change this:
 
 .. code-block:: JSON
-		
-    "dependencies": [ ],
+
+   {
+     "dependencies": [ ]
+   }
 
 to this:
 
 .. code-block:: JSON
-		
-    "dependencies": [ "v3d" ],
+
+   {
+     "dependencies": [ "v3d" ]
+   }
 
 To know more about :program:`dylan` package manager visit
-`Dylan tool <https://opendylan.org/documentation/dylan-tool/>`_
+`Dylan tool <https://opendylan.org/documentation/dylan-tool/>`_.
 
 Quick summary of ``v3d``
 ========================


### PR DESCRIPTION
I got this warning for both blocks:

`index.rst:27: WARNING: Could not lex literal_block as "JSON". Highlighting skipped.`

The new json isn't ideal because it makes it look like the "dependencies" setting is the only item in the entire config, but I couldn't find a better way. I tried to include `...` in the example but that causes errors also.